### PR TITLE
Fixing issue #11

### DIFF
--- a/src/managers/modorganizer.py
+++ b/src/managers/modorganizer.py
@@ -98,7 +98,7 @@ class MO2Instance(ModInstance):
                     continue
 
                 modname = utils.clean_string(mod.metadata["name"])
-
+                modname = modname.strip(". ")
                 # Enable mod in destination
                 if mod.enabled:
                     mods += "\n+" + modname
@@ -106,7 +106,7 @@ class MO2Instance(ModInstance):
                 # Disable mod in destination
                 else:
                     mods += "\n-" + modname
-            mods = mods.strip(" .")
+            mods = mods.strip()
             file.write(mods)
         self.log.debug("Created 'modlist.txt'.")
 

--- a/src/managers/modorganizer.py
+++ b/src/managers/modorganizer.py
@@ -106,7 +106,7 @@ class MO2Instance(ModInstance):
                 # Disable mod in destination
                 else:
                     mods += "\n-" + modname
-            mods = mods.strip()
+            mods = mods.strip(" .")
             file.write(mods)
         self.log.debug("Created 'modlist.txt'.")
 

--- a/src/managers/vortex.py
+++ b/src/managers/vortex.py
@@ -607,7 +607,7 @@ Vortex is running!"
                             self.log.debug(f"Rule reference: {reference}")
                             raise ValueError(f"Unknown rule type '{rule['type']}'!")
 
-            conflict_graph = utils.ConflictGraph(new_loadorder.copy())
+            conflict_graph = utils.ConflictGraph(new_loadorder)
             new_loadorder = conflict_graph.to_loadorder()
 
             # Replace Vortex's full mod names displayed name

--- a/src/managers/vortex.py
+++ b/src/managers/vortex.py
@@ -607,25 +607,8 @@ Vortex is running!"
                             self.log.debug(f"Rule reference: {reference}")
                             raise ValueError(f"Unknown rule type '{rule['type']}'!")
 
-                # Sort mod
-                if mod.overwriting_mods:
-                    # self.log.debug(f"Sorting mod '{mod}'...")
-
-                    old_index = index = new_loadorder.index(mod)
-
-                    # Get smallest index of all overwriting mods
-                    overwriting_mods = [
-                        new_loadorder.index(overwriting_mod)
-                        for overwriting_mod in mod.overwriting_mods
-                    ]
-                    index = min(overwriting_mods)
-                    # self.log.debug(
-                    #    f"Current index: {old_index} | Minimal index of overwriting_mods: {index}"
-                    # )
-
-                    if old_index > index:
-                        new_loadorder.insert(index, new_loadorder.pop(old_index))
-                        # self.log.debug(f"Moved mod '{mod}' from index {old_index} to {index}.")
+            conflict_graph = utils.ConflictGraph(new_loadorder.copy())
+            new_loadorder = conflict_graph.to_loadorder()
 
             # Replace Vortex's full mod names displayed name
             final_loadorder = []

--- a/src/utilities/__init__.py
+++ b/src/utilities/__init__.py
@@ -20,6 +20,7 @@ from .mod_item import ModItem
 from .stdout_pipe import StdoutPipe
 from .theme import Theme
 from .vortex_database import VortexDatabase
+from .conflict_graph import ConflictGraph
 
 
 def get_latest_version():

--- a/src/utilities/conflict_graph.py
+++ b/src/utilities/conflict_graph.py
@@ -1,0 +1,82 @@
+from .mod import Mod
+
+class Node: #used only internally within ConflictGraph
+    key: int
+    value: Mod
+    child_count: int
+    parent_count: int
+
+    def __init__(self, key, value, child_count = 0, parent_count = 0) -> None:
+        self.key = key
+        self.value = value
+        self.child_count = child_count
+        self.parent_count = parent_count
+
+
+class ConflictGraph:
+    nodes: set
+    edges: dict
+    used_flag: bool
+
+    def __init__(self, loaderder: list) -> None:
+        """Initialize the graph based on a list of mod objects.
+
+        Args:
+            loaderder (list): arbitraty list of mods
+        """
+        id = 0
+        self.nodes = []
+        self.edges = {}
+        self.used_flag = False
+        modname2id = {}
+        # insert all nodes
+        for mod in loaderder:
+            node = Node(key=id, value = mod, child_count = 0, parent_count = 0)
+            self.nodes.append(node)
+            modname2id[mod.name] = id
+            id += 1
+        # create all edges
+        for node in self.nodes:
+            for mod_late in node.value.overwriting_mods:
+                # find its node
+                node_late = self.nodes[modname2id[mod_late.name]]
+                # store the edge
+                if (not node.key in self.edges):
+                    self.edges[node.key] = []
+                self.edges[node.key].append(node_late)
+                node.child_count += 1
+                node_late.parent_count += 1
+
+
+    def to_loadorder(self):
+        """
+        The graph will be broken after this, so don't reuse the graph!
+
+        Returns:
+            A sorted list of mods, based on conflict rules.
+
+        """
+        assert self.used_flag == False
+        new_order = []
+        pop_stack = []
+        for node in self.nodes:
+            if(node.parent_count == 0):
+                # if it's out of the graph, output it first.
+                if(node.child_count == 0):
+                    new_order.append(node.value)
+                # if it's in the graph and has no parent, get ready to pop it.
+                else:
+                    pop_stack.append(node)
+        # remove nodes from the graph 
+        while(len(pop_stack) > 0):
+            node = pop_stack.pop()
+            if (node.key in self.edges):
+                for child in self.edges[node.key]:
+                    child.parent_count -= 1
+                    if (child.parent_count == 0):
+                        pop_stack.append(child)
+            new_order.append(node.value)
+        self.used_flag = True
+        return new_order
+
+


### PR DESCRIPTION
Added a mod conflict graph to aid sorting the mods properly. It put all mods in a directed graph with each edge being conflict rules, then pop out mods with no edges pointing to it iteratively. This should eliminate all previously improperly handled conflicts as tested on my end.

Also edited src/manager/vortex.py to use the graph to sort mods.

Also edited src/manager/modorganizer.py to strip modnames from ending with ".". As folders created on windows seems to not allow folder names ending with it, this would eliminate issues like this: 
![issueno2](https://github.com/Cutleast/Mod-Manager-Migrator/assets/22783566/2a9c1fae-dfee-4760-af7f-bf555ae69638)
